### PR TITLE
Fix jpegOrientation for camera sensors not at 90 degrees

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,7 +11,7 @@
         <activity
                 android:name=".MainActivity"
                 android:theme="@style/AppTheme.Camera"
-                android:screenOrientation="portrait">
+                android:screenOrientation="fullSensor">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
 


### PR DESCRIPTION
Verified with turning my phone in all directions and taking pictures!
Also works correctly for the front camera on my Nexus 5X.

Please test on your Nexus 6, it has a 90 degree mounted camera in the back and a 270 degree camera mounted in the front (for the 5X it's the other way around).
