### PR TITLE
Fix config on Camera recording

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 #### Add dependency
 
 ```gradle
-implementation 'co.infinum:goldeneye:1.1.1'
+implementation 'co.infinum:goldeneye:1.1.2'
 ```
 
 #### Initialize

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     ]
 
     ext.versions = [
-        goldeneye: '1.1.1',
+        goldeneye: '1.1.2',
         google   : '28.0.0',
         kotlin   : '1.3.10'
     ]

--- a/goldeneye/src/main/java/co/infinum/goldeneye/GoldenEye1Impl.kt
+++ b/goldeneye/src/main/java/co/infinum/goldeneye/GoldenEye1Impl.kt
@@ -138,7 +138,6 @@ internal class GoldenEye1Impl @JvmOverloads constructor(
         }
 
         state = CameraState.RECORDING_VIDEO
-        applyConfig()
         startPreview()
         camera?.unlock()
         videoRecorder?.startRecording(file, object : VideoCallback {


### PR DESCRIPTION
For some reason we apply new configuration twice which causes weird behavior. We should drop this and apply it only once later in the lifecycle.